### PR TITLE
Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/core/res/res/values/ion_config.xml
+++ b/core/res/res/values/ion_config.xml
@@ -70,4 +70,8 @@
     <!-- Time to give to the proximity sensor before toggling the flashlight with the Power button.
     Set to -1 to disable the proximity sensor check at all-->
     <integer name="config_flashlightProximityTimeout">300</integer>
+
+    <!-- Full screen aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
+    <item name="config_screenAspectRatio" format="float" type="dimen">2.1</item>
 </resources>

--- a/core/res/res/values/ion_symbols.xml
+++ b/core/res/res/values/ion_symbols.xml
@@ -62,4 +62,8 @@
 
   <!-- Power button proximity sensor check -->
   <java-symbol type="integer" name="config_flashlightProximityTimeout" />
+
+  <!-- Full screen aspect ratio -->
+  <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
+  <java-symbol type="dimen" name="config_screenAspectRatio" />
 </resources>

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -172,6 +172,7 @@ import android.app.servertransaction.TopResumedActivityChangeItem;
 import android.app.servertransaction.WindowVisibilityItem;
 import android.app.usage.UsageEvents.Event;
 import android.content.ComponentName;
+import android.content.res.Resources;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
@@ -415,6 +416,10 @@ public final class ActivityRecord extends ConfigurationContainer {
     private boolean mShowWhenLocked;
     private boolean mInheritShownWhenLocked;
     private boolean mTurnScreenOn;
+
+    // Full screen aspect ratio
+    private final float mFullScreenAspectRatio = Resources.getSystem().getFloat(
+                    com.android.internal.R.dimen.config_screenAspectRatio);
 
     /**
      * Current sequencing integer of the configuration, for skipping old activity configurations.
@@ -3090,7 +3095,9 @@ public final class ActivityRecord extends ConfigurationContainer {
     // TODO(b/36505427): Consider moving this method and similar ones to ConfigurationContainer.
     private void computeBounds(Rect outBounds, Rect containingAppBounds) {
         outBounds.setEmpty();
-        final float maxAspectRatio = info.maxAspectRatio;
+        final boolean higherAspectRatio = Resources.getSystem().getBoolean(
+                com.android.internal.R.bool.config_haveHigherAspectRatioScreen);
+        final float maxAspectRatio = higherAspectRatio ? mFullScreenAspectRatio : info.maxAspectRatio;
         final ActivityStack stack = getActivityStack();
         final float minAspectRatio = info.minAspectRatio;
 


### PR DESCRIPTION
This option forces apps to use full screen instead of old aspect ratio if the device supports it

Signed-off-by: Orges <oshabani@mymail.aacc.edu>